### PR TITLE
Modify `node_modules` file intentionally after adding `linguist-generated=false linguist-vendored=true`

### DIFF
--- a/node_modules/lodash.flatten/index.js
+++ b/node_modules/lodash.flatten/index.js
@@ -5,6 +5,8 @@
  * Released under MIT license <https://lodash.com/license>
  * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
  * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ *
+ * This is a test edit for files inside `node_modules`! Bad practice!
  */
 
 /** Used as references for various `Number` constants. */


### PR DESCRIPTION
By default, when editing files inside `node_modules/`, "File changed" tab shows the following as GitHub think they are generated file:

![Screen Shot 2021-05-10 at 14 06 08](https://user-images.githubusercontent.com/1425259/117608531-3b6c5480-b199-11eb-970d-af02cf388c44.png)


By adding the following line to `.gitattributes`, we can view the changes against files inside `node_modules/`:

```.gitignore
node_modules/lodash.flatten/**/* linguist-generated=false linguist-vendored=true
```